### PR TITLE
Hexens Audit: Improper validation of message padding during Poseidon decryption in EERC SDK

### DIFF
--- a/src/crypto/poseidon/poseidon.ts
+++ b/src/crypto/poseidon/poseidon.ts
@@ -227,7 +227,7 @@ export class Poseidon {
       }
     };
 
-    if (length > 3) {
+    if (length % 3) {
       if (length % 3 === 2) {
         checkEqual(
           msg[msg.length - 1],


### PR DESCRIPTION
{{PATH: src/crypto/poseidon/poseidon.ts:L199}}

{{poseidonDecrypt}} function implements decryption of the transfer amounts and balances via Poseidon decryption algorithm described in the Encryption with Poseidon paper. 

The current implementation validates message padding by checking if the message length exceeds 3 and evaluating {{length % 3}}.

{noformat}if (length > 3) {
  if (length % 3 === 2) {
    checkEqual(
      msg[msg.length - 1],
      this.field.zero,
      this.field,
      "The last element of the message must be 0",
    );
  } else if (length % 3 === 1) {
    checkEqual(
      msg[msg.length - 1],
      this.field.zero,
      this.field,
      "The last element of the message must be 0",
    );
    checkEqual(
      msg[msg.length - 2],
      this.field.zero,
      this.field,
      "The second to last element of the message must be 0",
    );
  }
}{noformat}

However, this approach misses cases where the message length is 1 or 2. In these scenarios, the condition {{length % 3 != 0}} still holds true, indicating the presence of padding, but the check fails due to the {{length > 3}} condition. As a result, padding in messages of length 1 or 2 remains unchecked.