### PR TITLE
Fix for generating random numbers in non-web context.

### DIFF
--- a/src/crypto/babyjub.ts
+++ b/src/crypto/babyjub.ts
@@ -207,7 +207,7 @@ export class BabyJub {
     try {
       const { randomBytes } = await import("node:crypto");
       return new Uint8Array(randomBytes(bytes).buffer);
-    } catch (e) {
+    } catch (_) {
       throw new Error("Unable to find a secure random number generator");
     }
   }

--- a/src/crypto/babyjub.ts
+++ b/src/crypto/babyjub.ts
@@ -204,10 +204,11 @@ export class BabyJub {
     ) {
       return window.crypto.getRandomValues(new Uint8Array(bytes));
     }
-    if (typeof require !== "undefined") {
+    try {
       const { randomBytes } = await import("node:crypto");
       return new Uint8Array(randomBytes(bytes).buffer);
+    } catch (e) {
+      throw new Error("Unable to find a secure random number generator");
     }
-    throw new Error("Unable to find a secure random number generator");
   }
 }


### PR DESCRIPTION
Want to be able to use this library in standalone scripts (e.g. for airdrops) outside of a web context.