### PR TITLE
fix: repair 'main' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@avalabs/ac-eerc-sdk",
   "version": "2.0.61",
   "type": "module",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": ["dist", "README.md", "package.json"],


### PR DESCRIPTION
I'm not that familiar with JS build systems but I think it shouldn't be referencing .cjs.

This fixed some issues with me using it in standalone scripts, anyway.